### PR TITLE
Including any errors for ExecuteResult the same way as for QueryResult

### DIFF
--- a/RqliteDotnet/Dto/ExecuteResult.cs
+++ b/RqliteDotnet/Dto/ExecuteResult.cs
@@ -8,4 +8,6 @@ public class ExecuteResult
     public int LastInsertId { get; set; }
     [JsonPropertyName("rows_affected")]
     public int RowsAffected { get; set; }
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
 }


### PR DESCRIPTION
Hi. 
The `QueryResult` dto has a field for errors that will contain eventual errors regarding your query.
This PR adds the same field to the `ExecuteResult` dto. 