### PR TITLE
Make JsonSerializerOptions Static to Reduce Allocations and Resolve CA1869

### DIFF
--- a/RqliteDotnet/HttpClientExtensions.cs
+++ b/RqliteDotnet/HttpClientExtensions.cs
@@ -11,7 +11,7 @@ public static class HttpClientExtensions
 
         response.EnsureSuccessStatusCode();
 
-        var result = JsonSerializer.Deserialize<T>(content, new JsonSerializerOptions() { PropertyNameCaseInsensitive = true });
+        var result = JsonSerializer.Deserialize<T>(content, JsonConfig.DeserializeOptions);
 
         return result!;
     }

--- a/RqliteDotnet/JsonConfig.cs
+++ b/RqliteDotnet/JsonConfig.cs
@@ -1,0 +1,11 @@
+using System.Text.Json;
+
+namespace RqliteDotnet;
+
+internal static class JsonConfig
+{
+    public static readonly JsonSerializerOptions DeserializeOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+}

--- a/RqliteDotnet/RqliteClient.cs
+++ b/RqliteDotnet/RqliteClient.cs
@@ -45,7 +45,7 @@ public class RqliteClient : IRqliteClient, IDisposable
         var r = await _httpClient.GetAsync(url, cancellationToken);
         var str = await r.Content.ReadAsStringAsync(cancellationToken);
 
-        var result = JsonSerializer.Deserialize<QueryResults>(str, new JsonSerializerOptions() { PropertyNameCaseInsensitive = true });
+        var result = JsonSerializer.Deserialize<QueryResults>(str, JsonConfig.DeserializeOptions);
         return result;
     }
 


### PR DESCRIPTION
Extract `JsonSerializerOptions` into a static instance to eliminate repeated allocations and resolve [CA1869](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1869). This reduces per-request memory pressure.

A benchmark comparing static vs non-static options shows identical execution time but lower allocations when using the static instance:

| UseStaticJsonSerializerOptions | Mean     | Allocated |
|-------------------------------|---------:|----------:|
| False                         | 170.6 ms |    6.1 MB |
| True                          | 171.6 ms |   5.88 MB |

Approximately 4% reduction in memory usage.

Attaching the benchmark code below:

```csharp
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Order;
using BenchmarkDotNet.Running;
using DotNet.Testcontainers.Builders;
using DotNet.Testcontainers.Containers;

namespace RqliteDotnet.Benchmarks;

public static class Program
{
    public static void Main(string[] args)
    {
        BenchmarkRunner.Run<JsonSeralizerOptionsStaticVsNonStatic>();
    }

    [MemoryDiagnoser]
    [Orderer(SummaryOrderPolicy.FastestToSlowest)]
    public class JsonSeralizerOptionsStaticVsNonStatic
    {
        private RqliteClient _client = null!;
        private IContainer _container = null!;

        [Params(false, true)]
        // ReSharper disable once UnassignedField.Global
        public bool UseStaticJsonSerializerOptions;

        [GlobalSetup]
        public async Task Setup()
        {
            const int containerPort = 4001;

            _container = new ContainerBuilder()
                .WithImage("rqlite/rqlite:9.1.2")
                .WithPortBinding(containerPort, true)
                .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(r => r.ForPort(containerPort))
                    .UntilMessageIsLogged("is now Leader", o => o.WithTimeout(TimeSpan.FromSeconds(20))))
                .Build();

            await _container.StartAsync();

            var mappedPublicPort = _container.GetMappedPublicPort(containerPort);

            _client = new RqliteClient($"http://localhost:{mappedPublicPort}");
            _client.UseStaticJsonSerializerOptions = UseStaticJsonSerializerOptions;

            await _client.Execute("CREATE TABLE foo (id INTEGER NOT NULL PRIMARY KEY, name TEXT, age INTEGER)");

            await _client.Execute("INSERT INTO foo (id, name, age) VALUES(1,'john', 42)");
        }

        [GlobalCleanup]
        public async Task Cleanup()
        {
            await _container.DisposeAsync();
            _client.Dispose();
        }

        [Benchmark]
        public async Task QueryData()
        {
            for (var i = 0; i < 1000; i++)
            {
                _ = await _client.Query("select * from foo");
            }
        }
    }
}
```