### PR TITLE
Fix warning

### DIFF
--- a/RqliteDotnet.IntegrationTest/RqliteClientTests.cs
+++ b/RqliteDotnet.IntegrationTest/RqliteClientTests.cs
@@ -18,8 +18,7 @@ public class RqliteClientTests
     [SetUp]
     public async Task Setup()
     {
-        _container = new ContainerBuilder()
-            .WithImage("rqlite/rqlite:9.1.2")
+        _container = new ContainerBuilder("rqlite/rqlite:9.1.2")
             .WithPortBinding(Port, true)
             .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(r => r.ForPort(Port))
                 .UntilMessageIsLogged("is now Leader", o => o.WithTimeout(TimeSpan.FromSeconds(20))))


### PR DESCRIPTION
Don't use deprecated constructor in Testcontainers