### PR TITLE
More detailed exception when column is missing from result when using  the Orm Client

### DIFF
--- a/RqliteDotnet.Test/RqliteClientTests.cs
+++ b/RqliteDotnet.Test/RqliteClientTests.cs
@@ -1,4 +1,4 @@
-using System.Threading;
+using System.Data;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using RqliteDotnet.Dto;
@@ -14,7 +14,7 @@ public class RqliteClientTests
 
         var rqClient = new RqliteClient("http://localhost:6000", client);
         var queryresult = await rqClient.Query("select * from foo");
-        
+
         Assert.That(queryresult!.Results!.Count, Is.EqualTo(1));
         Assert.That(queryresult!.Results[0]!.Columns!.Count, Is.EqualTo(2));
         Assert.That(queryresult.Results[0].Columns[0], Is.EqualTo("id"));
@@ -30,12 +30,25 @@ public class RqliteClientTests
 
         var rqClient = new RqliteOrmClient("http://localhost:6000", client);
         var queryresults = await rqClient.Query<FooResultDto>("select * from foo");
-        
+
         Assert.That(queryresults.Count, Is.EqualTo(1));
         Assert.That(queryresults[0].Id, Is.EqualTo(1));
         Assert.That(queryresults[0].Name, Is.EqualTo("john"));
     }
-    
+
+
+    [Test]
+    public async Task QueryWithGenerics_ExceptionWhenNoColumnForProperty()
+    {
+        var client = HttpClientMock.GetQueryMock();
+
+        var rqClient = new RqliteOrmClient("http://localhost:6000", client);
+        Assert.ThrowsAsync<DataException>(async () =>
+        {
+            var _ = await rqClient.Query<FooResultWithExtraColumnDto>("select * from foo", cancellationToken: default);
+        });
+    }
+
     [Test]
     public async Task ParametrizedQueryWithGenerics_Works()
     {
@@ -43,17 +56,36 @@ public class RqliteClientTests
 
         var rqClient = new RqliteOrmClient("http://localhost:6000", client);
         var queryresults = await rqClient.QueryParams<NamedQueryParameter, FooResultDto>("select * from foo where Name = :name",
-            default(CancellationToken),
+            default,
             new NamedQueryParameter()
             {
-                Name = "name", 
-                ParamType = QueryParamType.String, 
+                Name = "name",
+                ParamType = QueryParamType.String,
                 Value = "john"
             });
-        
+
         Assert.That(queryresults.Count, Is.EqualTo(1));
         Assert.That(queryresults[0].Id, Is.EqualTo(1));
         Assert.That(queryresults[0].Name, Is.EqualTo("john"));
+    }
+
+    [Test]
+    public async Task ParametrizedQueryWithGenerics_ExceptionWhenNoColumnForProperty()
+    {
+        var client = HttpClientMock.GetParamQueryMock();
+
+        var rqClient = new RqliteOrmClient("http://localhost:6000", client);
+        Assert.ThrowsAsync<DataException>(async () =>
+        {
+            var _ = await rqClient.QueryParams<NamedQueryParameter, FooResultWithExtraColumnDto>("select * from foo where Name = :name",
+            cancellationToken: default,
+            new NamedQueryParameter()
+            {
+                Name = "name",
+                ParamType = QueryParamType.String,
+                Value = "john"
+            });
+        });
     }
 
     [Test]
@@ -63,12 +95,12 @@ public class RqliteClientTests
 
         var rqClient = new RqliteClient("http://localhost:6000", client);
         var result = await rqClient.Execute("create table newfoo (id integer primary key not null)");
-        
+
         Assert.That(result!.Results!.Count, Is.EqualTo(1));
         Assert.That(result.Results[0].RowsAffected, Is.EqualTo(1));
         Assert.That(result.Results[0].LastInsertId, Is.EqualTo(2));
     }
-    
+
     [Test]
     public async Task ParametrizedExecute_Works()
     {
@@ -82,7 +114,7 @@ public class RqliteClientTests
                         , new NamedQueryParameter {Name = "oldName", Value = "john", ParamType = QueryParamType.String}
                     }
                     )}, DbFlag.Transaction);
-        
+
         Assert.That(result!.Results!.Count, Is.EqualTo(1));
         Assert.That(result.Results[0].RowsAffected, Is.EqualTo(1));
         Assert.That(result.Results[0].LastInsertId, Is.EqualTo(2));
@@ -92,13 +124,13 @@ public class RqliteClientTests
     public async Task BasicQueryParam_Works()
     {
         var client = HttpClientMock.GetParamQueryMock();
-        
+
         var rqClient = new RqliteClient("http://localhost:6000", client);
-        var result = await rqClient.QueryParams<QueryParameter>("select * from foo where name = ?", default(CancellationToken), new QueryParameter()
+        var result = await rqClient.QueryParams<QueryParameter>("select * from foo where name = ?", cancellationToken: default, new QueryParameter()
         {
-            ParamType = QueryParamType.String, Value = "john"
+            ParamType = QueryParamType.String,
         });
-        
+
         Assert.That(result!.Results!.Count, Is.EqualTo(1));
         Assert.That(result!.Results[0]!.Values![0]!.Count, Is.EqualTo(2));
     }
@@ -117,7 +149,7 @@ public class RqliteClientTests
         var firstNodeExists = result.TryGetValue("shk967khgoip", out firstValue);
         Assert.That(firstNodeExists, Is.EqualTo(true));
         Assert.That(firstValue!.Id, Is.EqualTo("shk967khgoip"));
-        
+
         NodeInfo secondValue;
         var secondValueExists = result.TryGetValue("xjhfl76s5hkpq", out secondValue);
         Assert.That(secondValueExists, Is.EqualTo(true));
@@ -129,4 +161,11 @@ public class FooResultDto
 {
     public int Id { get; set; }
     public string Name { get; set; }
+}
+
+public class FooResultWithExtraColumnDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public int Age { get; set; }
 }

--- a/RqliteDotnet/IRqliteOrmClient.cs
+++ b/RqliteDotnet/IRqliteOrmClient.cs
@@ -10,7 +10,7 @@ public interface IRqliteOrmClient : IRqliteClient
     /// <param name="query">Query to execute</param>
     /// <typeparam name="T">Type of result object</typeparam>
     /// <returns></returns>
-    Task<List<T>> Query<T>(string query) where T: new();
+    Task<List<T>> Query<T>(string query, CancellationToken cancellationToken) where T: new();
 
     Task<List<U>> QueryParams<T, U>(string query, CancellationToken cancellationToken, params T[] qps) 
         where T: QueryParameter 

--- a/RqliteDotnet/RqliteOrmClient.cs
+++ b/RqliteDotnet/RqliteOrmClient.cs
@@ -1,5 +1,4 @@
 using System.Data;
-
 using RqliteDotnet.Dto;
 
 namespace RqliteDotnet;
@@ -9,7 +8,7 @@ public class RqliteOrmClient : RqliteClient, IRqliteOrmClient
     public RqliteOrmClient(string uri, HttpClient? client = null) : base(uri, client) { }
 
     /// <inheritdoc />
-    public async Task<List<T>> Query<T>(string query) where T : new()
+    public async Task<List<T>> Query<T>(string query, CancellationToken cancellationToken = default) where T : new()
     {
         var response = await Query(query);
         if (response?.Results!.Count > 1)
@@ -28,7 +27,7 @@ public class RqliteOrmClient : RqliteClient, IRqliteOrmClient
         return list;
     }
 
-    public async Task<List<U>> QueryParams<T, U>(string query, CancellationToken cancellationToken, params T[] qps)
+    public async Task<List<U>> QueryParams<T, U>(string query, CancellationToken cancellationToken = default, params T[] qps)
         where T : QueryParameter
         where U : new()
     {

--- a/RqliteDotnet/RqliteOrmClient.cs
+++ b/RqliteDotnet/RqliteOrmClient.cs
@@ -1,11 +1,12 @@
 using System.Data;
+
 using RqliteDotnet.Dto;
 
 namespace RqliteDotnet;
 
 public class RqliteOrmClient : RqliteClient, IRqliteOrmClient
 {
-    public RqliteOrmClient(string uri, HttpClient? client = null) : base(uri, client) {}
+    public RqliteOrmClient(string uri, HttpClient? client = null) : base(uri, client) { }
 
     /// <inheritdoc />
     public async Task<List<T>> Query<T>(string query) where T : new()
@@ -21,20 +22,7 @@ public class RqliteOrmClient : RqliteClient, IRqliteOrmClient
 
         for (int i = 0; i < res?.Values?.Count; i++)
         {
-            var dto = new T();
-
-            foreach (var prop in typeof(T).GetProperties())
-            {
-                if (res.Columns != null)
-                {
-                    var index = res.Columns.FindIndex(c => c.ToLower() == prop.Name.ToLower());
-                    var val = GetValue(res.Types?[index], res.Values[i][index]);
-
-                    prop.SetValue(dto, val);
-                }
-            }
-
-            list.Add(dto);
+            list.Add(ConstructObjectFromQueryResult<T>(res, i));
         }
 
         return list;
@@ -55,22 +43,33 @@ public class RqliteOrmClient : RqliteClient, IRqliteOrmClient
 
         for (int i = 0; i < res.Values?.Count; i++)
         {
-            var dto = new U();
-
-            foreach (var prop in typeof(U).GetProperties())
-            {
-                if (res.Columns != null)
-                {
-                    var index = res.Columns.FindIndex(c => c.ToLower() == prop.Name.ToLower());
-                    var val = GetValue(res.Types?[index], res.Values[i][index]);
-
-                    prop.SetValue(dto, val);
-                }
-            }
-
-            list.Add(dto);
+            list.Add(ConstructObjectFromQueryResult<U>(res, i));
         }
 
         return list;
+    }
+
+    private T ConstructObjectFromQueryResult<T>(QueryResult res, int i) where T : new()
+    {
+        ArgumentNullException.ThrowIfNull(res.Values);
+
+        var dto = new T();
+
+        foreach (var prop in typeof(T).GetProperties())
+        {
+            if (res.Columns != null)
+            {
+                var index = res.Columns.FindIndex(col => string.Equals(col, prop.Name, StringComparison.InvariantCultureIgnoreCase));
+                if (index == -1)
+                {
+                    throw new DataException("No Column for property {prop.Name}");
+                }
+                var val = GetValue(res.Types?[index], res.Values[i][index]);
+
+                prop.SetValue(dto, val);
+            }
+        }
+
+        return dto;
     }
 }


### PR DESCRIPTION
If the code that the ORM Client uses to map the query results to a C# object fails to find a column for one of the Properties on the class an `IndexOutOfRangeException` is thrown. This can be quite hard to track down and localize. 

This PR adds a check for a valid index and throws an `DataException` specifying which column is missing. 