### PR TITLE
Fix: Missing $ for string interpolation in exception message

### DIFF
--- a/RqliteDotnet.Test/RqliteClientTests.cs
+++ b/RqliteDotnet.Test/RqliteClientTests.cs
@@ -42,10 +42,11 @@ public class RqliteClientTests
         var client = HttpClientMock.GetQueryMock();
 
         var rqClient = new RqliteOrmClient("http://localhost:6000", client);
-        Assert.ThrowsAsync<DataException>(async () =>
+        var exception = Assert.ThrowsAsync<DataException>(async () =>
         {
             var _ = await rqClient.Query<FooResultWithExtraColumnDto>("select * from foo", cancellationToken: default);
         });
+        Assert.That(exception.Message, Does.Contain("Age"));
     }
 
     [Test]
@@ -74,7 +75,7 @@ public class RqliteClientTests
         var client = HttpClientMock.GetParamQueryMock();
 
         var rqClient = new RqliteOrmClient("http://localhost:6000", client);
-        Assert.ThrowsAsync<DataException>(async () =>
+        var exception = Assert.ThrowsAsync<DataException>(async () =>
         {
             var _ = await rqClient.QueryParams<NamedQueryParameter, FooResultWithExtraColumnDto>("select * from foo where Name = :name",
             cancellationToken: default,
@@ -85,6 +86,7 @@ public class RqliteClientTests
                 Value = "john"
             });
         });
+        Assert.That(exception.Message, Does.Contain("Age"));
     }
 
     [Test]

--- a/RqliteDotnet/RqliteOrmClient.cs
+++ b/RqliteDotnet/RqliteOrmClient.cs
@@ -61,7 +61,7 @@ public class RqliteOrmClient : RqliteClient, IRqliteOrmClient
                 var index = res.Columns.FindIndex(col => string.Equals(col, prop.Name, StringComparison.InvariantCultureIgnoreCase));
                 if (index == -1)
                 {
-                    throw new DataException("No Column for property {prop.Name}");
+                    throw new DataException($"No Column for property {prop.Name}");
                 }
                 var val = GetValue(res.Types?[index], res.Values[i][index]);
 


### PR DESCRIPTION
In my previous pr #58 I missed the `$` for string interpolation in the exception message. Hence the error message said "No _Column for property {prop.Name}"_ instead of , ex: _"No Column for property "Age"_. 

This PR fixes that mistake and adds to the tests to verify that the name of the missing column is in the error message. 